### PR TITLE
Add bilingual layout improvements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,6 +10,31 @@ nav a {
     color: aqua;
 }
 
+.site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+}
+
+.site-header .logo img {
+    height: 40px;
+}
+
+.lang-switch a {
+    margin-left: 5px;
+}
+
+.fade-in {
+    opacity: 0;
+    animation: fadeIn 1s forwards;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
 h1 {
     color: #333;
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('fade-in');
+});

--- a/includes/lang.php
+++ b/includes/lang.php
@@ -1,0 +1,57 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Determine current language
+$lang = 'de';
+if (isset($_GET['lang'])) {
+    $langParam = strtolower($_GET['lang']);
+    if (in_array($langParam, ['de', 'en'])) {
+        $lang = $langParam;
+        $_SESSION['lang'] = $lang;
+    }
+} elseif (isset($_SESSION['lang'])) {
+    $lang = $_SESSION['lang'];
+}
+
+$translations = [
+    'de' => [
+        'home' => 'Home',
+        'about' => 'Über mich',
+        'projects' => 'Projekte',
+        'contact' => 'Kontakt',
+        'login' => 'Login',
+        'logout' => 'Logout',
+        'welcome_title' => 'Willkommen zu meinem Portfolio',
+        'welcome_text' => 'Ich bin [ Dein Name ], ein [ Dein Beruf ]. Hier findest du eine Auswahl meiner besten Projekte.',
+        'read_more' => 'Mehr über mich',
+        'about_intro' => 'Ich bin [Dein Name], ein leidenschaftlicher [Berufsbezeichnung].',
+        'contact_intro' => 'Interessiert an einer Zusammenarbeit? Kontaktieren Sie mich per E-Mail:',
+        'projects_title' => 'Meine Projekte',
+        'no_projects' => 'Keine Projekte verfügbar.',
+        'more_info' => 'Mehr erfahren'
+    ],
+    'en' => [
+        'home' => 'Home',
+        'about' => 'About me',
+        'projects' => 'Work',
+        'contact' => 'Contact',
+        'login' => 'Login',
+        'logout' => 'Logout',
+        'welcome_title' => 'Welcome to my portfolio',
+        'welcome_text' => 'I am [Your Name], a [Your Profession]. Here you can find a selection of my best projects.',
+        'read_more' => 'Read more',
+        'about_intro' => 'I am [Your Name], a passionate [Profession].',
+        'contact_intro' => 'Interested in collaborating? Contact me via email:',
+        'projects_title' => 'My Projects',
+        'no_projects' => 'No projects available.',
+        'more_info' => 'Learn more'
+    ]
+];
+
+function t(string $key): string {
+    global $translations, $lang;
+    return $translations[$lang][$key] ?? $key;
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,8 +1,8 @@
-<?php include 'views/header.php';
-?>
-<h1>Willkommen zu meinem Portfolio</h1>
-<p>Ich bin [ Dein Name ], ein [ Dein Beruf ]. Hier findest du eine Auswahl meiner besten Projekte.</p>
-<img src = 'assets/img/hero.jpg' alt = 'Portfolio Bild'>
-<a href = 'pages/about.php'>Mehr über mich</a>
-<?php include 'views/footer.php';
-?>
+<?php include 'views/header.php'; ?>
+<main>
+    <h1><?= t('welcome_title') ?></h1>
+    <p><?= t('welcome_text') ?></p>
+    <img src="assets/img/hero.jpg" alt="Portfolio Bild">
+    <a href="pages/about.php"><?= t('read_more') ?></a>
+</main>
+<?php include 'views/footer.php'; ?>

--- a/pages/about.php
+++ b/pages/about.php
@@ -1,12 +1,14 @@
 <?php
 include '../includes/config.php';
-include '../views/header.php';
-session_start();
+include '../includes/lang.php';
 
 $role = $_SESSION["role"] ?? "public";
+
+include '../views/header.php';
 ?>
-<h1>Über mich</h1>
-<p>Ich bin [Dein Name], ein leidenschaftlicher [Berufsbezeichnung].</p>
+<main>
+<h1><?= t('about') ?></h1>
+<p><?= t('about_intro') ?></p>
 
 <?php if ($role == "recruiter"): ?>
     <h2>Berufliche Details</h2>
@@ -21,4 +23,5 @@ $role = $_SESSION["role"] ?? "public";
     <p>Mehr Infos erhalten Sie nach Anmeldung.</p>
 <?php endif; ?>
 
+</main>
 <?php include '../views/footer.php'; ?>

--- a/pages/contact.php
+++ b/pages/contact.php
@@ -1,6 +1,9 @@
-<?php include '../views/header.php';
+<?php
+include '../includes/lang.php';
+include '../views/header.php';
 ?>
-<h1>Kontakt</h1>
-<p>Interessiert an einer Zusammenarbeit? Kontaktieren Sie mich per E-Mail: <a href = 'mailto:email@domain.com'>email@domain.com</a></p>
-<?php include '../views/footer.php';
-?>
+<main>
+<h1><?= t('contact') ?></h1>
+<p><?= t('contact_intro') ?> <a href="mailto:email@domain.com">email@domain.com</a></p>
+</main>
+<?php include '../views/footer.php'; ?>

--- a/pages/projects.php
+++ b/pages/projects.php
@@ -1,9 +1,10 @@
 <?php
 include '../includes/config.php';
-session_start();
-include '../views/header.php'; 
+include '../includes/lang.php';
 
 $role = $_SESSION["role"] ?? "public";
+
+include '../views/header.php';
 
 if ($role === "admin") {
     $sql = "SELECT DISTINCT p.* FROM projects p";
@@ -20,47 +21,11 @@ if ($role === "admin") {
 $projects = $stmt->fetchAll();
 ?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Projekte</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <style>
-        .image-slider {
-            position: relative;
-            width: 300px;
-            height: 200px;
-            overflow: hidden;
-        }
-        .image-slider img {
-            width: 100%;
-            height: auto;
-            display: none;
-        }
-        .slider-controls {
-            position: absolute;
-            top: 50%;
-            width: 100%;
-            display: flex;
-            justify-content: space-between;
-            transform: translateY(-50%);
-        }
-        .slider-controls button {
-            background-color: rgba(0, 0, 0, 0.5);
-            color: white;
-            border: none;
-            padding: 5px;
-            cursor: pointer;
-        }
-    </style>
-</head>
-<body>
-
-    <h1>Meine Projekte</h1>
+<main>
+    <h1><?= t('projects_title') ?></h1>
     <ul>
         <?php if (empty($projects)): ?>
-            <li>Keine Projekte verfügbar.</li>
+            <li><?= t('no_projects') ?></li>
         <?php else: ?>
             <?php foreach ($projects as $project): ?>
                 <li style="border: 1px solid #ccc; padding: 10px; margin-bottom: 10px;">
@@ -80,12 +45,12 @@ $projects = $stmt->fetchAll();
 
                     <p><strong>Sichtbar für:</strong> <?= implode(", ", $roles) ?></p>
 
-                    <a href="project_detail.php?id=<?= $project['id'] ?>">🔍 Mehr erfahren</a>
+                    <a href="project_detail.php?id=<?= $project['id'] ?>">🔍 <?= t('more_info') ?></a>
                 </li>
             <?php endforeach; ?>
         <?php endif; ?>
     </ul>
 
-    <a href="../index.php">⬅ Zurück zur Startseite</a>
-</body>
-</html>
+    <a href="../index.php">⬅ <?= t('home') ?></a>
+</main>
+<?php include '../views/footer.php'; ?>

--- a/views/header.php
+++ b/views/header.php
@@ -1,11 +1,24 @@
+<?php
+include_once __DIR__ . '/../includes/lang.php';
+?>
 <!DOCTYPE html>
-<html lang="de">
+<html lang="<?= $lang ?>">
 <head>
     <meta charset="UTF-8">
     <title>Portfolio Zeno</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <link rel="icon" type="image/x-icon" href="./favicon.png">
-    <link rel="shortcut icon" href="./favicon.png">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <script src="/assets/js/app.js" defer></script>
+    <link rel="icon" type="image/x-icon" href="/favicon.png">
+    <link rel="shortcut icon" href="/favicon.png">
 </head>
-<body>
+<body class="fade-in">
+<header class="site-header">
+    <div class="logo">
+        <!-- Ersetze logo.png durch dein eigenes Logo -->
+        <img src="/assets/img/logo.png" alt="Logo">
+    </div>
+    <div class="lang-switch">
+        <a href="?lang=de">DE</a> | <a href="?lang=en">EN</a>
+    </div>
+</header>
 <?php include 'navigation.php'; ?>

--- a/views/navigation.php
+++ b/views/navigation.php
@@ -1,9 +1,8 @@
-<?php session_start(); ?>
 <nav>
-    <a href="../index.php">Home</a>
-    <a href="../pages/about.php">Über mich</a>
-    <a href="../pages/projects.php">Projekte</a>
-    <a href="../pages/contact.php">Kontakt</a>
+    <a href="../index.php"><?= t('home') ?></a>
+    <a href="../pages/about.php"><?= t('about') ?></a>
+    <a href="../pages/projects.php"><?= t('projects') ?></a>
+    <a href="../pages/contact.php"><?= t('contact') ?></a>
 
     <?php if (isset($_SESSION["user_id"])): ?>
         <?php if ($_SESSION["role"] == 'admin'): ?>
@@ -19,8 +18,8 @@
             <a href="../pages/familyandfriends.php">Familie & Freunde</a>
         <?php endif; ?>
 
-        <a href="../auth/logout.php">Logout</a>
+        <a href="../auth/logout.php"><?= t('logout') ?></a>
     <?php else: ?>
-        <a href="../auth/login.php">Login</a>
+        <a href="../auth/login.php"><?= t('login') ?></a>
     <?php endif; ?>
 </nav>


### PR DESCRIPTION
## Summary
- create translation system and German/English strings
- redesign header with logo placeholder and language switcher
- implement fade-in animation and style tweaks
- translate main pages (home, about, projects, contact)

## Testing
- `php -l index.php`
- `php -l pages/about.php`
- `php -l pages/contact.php`
- `php -l pages/projects.php`
- `php -l views/header.php`
- `php -l views/navigation.php`
- `php -l includes/lang.php`


------
https://chatgpt.com/codex/tasks/task_e_6889f8d58948832fa8ced053e092d372